### PR TITLE
Updates kv-asset-handler to ~0.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
   "author": "Ashley Lewis <ashleymichal@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@cloudflare/kv-asset-handler": "^0.0.5"
+    "@cloudflare/kv-asset-handler": "~0.0.11"
   }
 }


### PR DESCRIPTION
caret only allows changes to the left-most non-zero value – so ^0.0.5 (which is what's in the repo) will only install version 0.0.5. 0.0.X or ~0.0.11 will allow users to get patch updates automatically.
